### PR TITLE
[TODO-5424] Update deprecated command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
     # Extract current branch name
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${{ inputs.git-ref }})"
+      run: echo "branch=$(echo ${{ inputs.git-ref }})" >> $GITHUB_OUTPUT
       id: extract_branch
 
     # Authenticate onto JIRA
@@ -53,8 +53,8 @@ runs:
         jiraId=${jiraId%_*}
         jiraId=${jiraId#*/}
         echo $jiraId
-        echo "##[set-output name=id;]$(echo $jiraId)"
-    
+        echo "id=$(echo $jiraId)" >> $GITHUB_OUTPUT
+
     # Actually change the JIRA issue status
     - name: Transition issue
       uses: atlassian/gajira-transition@master


### PR DESCRIPTION
Lien de l'avertissement de dépréciation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Lien du guide de migration: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter